### PR TITLE
Add options to ignore retweets and boosts (reblogs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ Enable automatic status/favourite deletion with config options. Example:
 delete_older_statuses = true
 # Delete Mastodon favourites that are older than 90 days
 delete_older_favs = true
+# Do not sync reblogs (boosts)
+sync_reblogs = false
 
 [mastodon.app]
 base = "https://mastodon.social"
@@ -56,6 +58,8 @@ user_name = "example"
 delete_older_statuses = true
 # Delete Twitter likes that are older than 90 days
 delete_older_favs = true
+# Do not sync retweets
+sync_retweets = false
 ```
 
 ## Preview what's going to be synced

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,6 +41,7 @@ fn run() -> Result<()> {
                     // enable this explicitly.
                     delete_older_statuses: false,
                     delete_older_favs: false,
+                    sync_reblogs: true,
                 },
                 twitter: twitter_config,
             };
@@ -107,7 +108,13 @@ fn run() -> Result<()> {
         };
         tweets.append(&mut (*next_tweets).to_vec());
     }
-    let mut posts = determine_posts(&mastodon_statuses, &tweets);
+
+    let options = SyncOptions {
+        sync_reblogs: config.mastodon.sync_reblogs,
+        sync_retweets: config.twitter.sync_retweets,
+    };
+
+    let mut posts = determine_posts(&mastodon_statuses, &tweets, &options);
 
     posts = filter_posted_before(posts, args.dry_run)?;
 

--- a/src/registration.rs
+++ b/src/registration.rs
@@ -60,6 +60,7 @@ pub fn twitter_register() -> Result<TwitterConfig> {
             user_name: screen_name,
             delete_older_statuses: false,
             delete_older_favs: false,
+            sync_retweets: true,
         }),
         _ => unreachable!(),
     }

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -898,9 +898,9 @@ QT test123: Verhalten bei #Hausdurchsuchung"
         assert!(posts.tweets.is_empty());
     }
 
-    // Test that quote tweets are synced without the quoted tweet when `sync_retweets=false`
+    // Test that quote tweets are synced when `sync_retweets=false`
     #[test]
-    fn quote_tweets_are_synced_without_quoted_text() {
+    fn quote_tweets_are_synced_when_ignoring_retweets() {
         let mut original_tweet = get_twitter_status();
         original_tweet.text = "Original text".to_string();
         original_tweet.user = Some(Box::new(get_twitter_user()));

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -28,12 +28,27 @@ pub struct NewMedia {
     pub alt_text: Option<String>,
 }
 
-pub fn determine_posts(mastodon_statuses: &[Status], twitter_statuses: &[Tweet]) -> StatusUpdates {
+#[derive(Debug, Clone)]
+pub struct SyncOptions {
+    pub sync_reblogs: bool,
+    pub sync_retweets: bool,
+}
+
+pub fn determine_posts(
+    mastodon_statuses: &[Status],
+    twitter_statuses: &[Tweet],
+    options: &SyncOptions,
+) -> StatusUpdates {
     let mut updates = StatusUpdates {
         tweets: Vec::new(),
         toots: Vec::new(),
     };
     'tweets: for tweet in twitter_statuses {
+        if tweet.retweeted == Some(true) && !options.sync_retweets {
+            // Skip retweets when sync_retweets is disabled
+            continue;
+        }
+
         for toot in mastodon_statuses {
             // If the tweet already exists we can stop here and know that we are
             // synced.
@@ -49,6 +64,10 @@ pub fn determine_posts(mastodon_statuses: &[Status], twitter_statuses: &[Tweet])
     }
 
     'toots: for toot in mastodon_statuses {
+        if toot.reblog.is_some() && !options.sync_reblogs {
+            // Skip reblogs when sync_reblogs is disabled
+            continue;
+        }
         // If this is a reblog/boost then take the URL to the original toot.
         let post = match &toot.reblog {
             None => tweet_shorten(&mastodon_toot_get_text(toot), &toot.url),
@@ -398,6 +417,11 @@ mod tests {
     use egg_mode::tweet::{ExtendedTweetEntities, TweetEntities, TweetSource};
     use egg_mode::user::{TwitterUser, UserEntities, UserEntityDetail};
 
+    static DEFAULT_SYNC_OPTIONS: SyncOptions = SyncOptions {
+        sync_reblogs: true,
+        sync_retweets: true,
+    };
+
     #[test]
     fn tweet_shortening() {
         let toot = "#MASTODON POST PRIVACY - who can see your post?
@@ -460,7 +484,7 @@ UNLISTED 🔓 ✅ Tagged people
 
         let tweets = vec![tweet];
         let statuses = vec![status];
-        let posts = determine_posts(&statuses, &tweets);
+        let posts = determine_posts(&statuses, &tweets, &DEFAULT_SYNC_OPTIONS);
         assert!(posts.toots.is_empty());
         assert!(posts.tweets.is_empty());
     }
@@ -482,7 +506,7 @@ UNLISTED 🔓 ✅ Tagged people
 
         let tweets = vec![tweet];
         let statuses = vec![status];
-        let posts = determine_posts(&statuses, &tweets);
+        let posts = determine_posts(&statuses, &tweets, &DEFAULT_SYNC_OPTIONS);
         assert!(posts.toots.is_empty());
         assert!(posts.tweets.is_empty());
     }
@@ -493,7 +517,7 @@ UNLISTED 🔓 ✅ Tagged people
     fn mastodon_html_decode() {
         let mut status = get_mastodon_status();
         status.content = "<p>You &amp; me!</p>".to_string();
-        let posts = determine_posts(&vec![status], &Vec::new());
+        let posts = determine_posts(&vec![status], &Vec::new(), &DEFAULT_SYNC_OPTIONS);
         assert_eq!(posts.tweets[0].text, "You & me!");
     }
 
@@ -503,7 +527,7 @@ UNLISTED 🔓 ✅ Tagged people
     fn twitter_html_decode() {
         let mut status = get_twitter_status();
         status.text = "You &amp; me!".to_string();
-        let posts = determine_posts(&Vec::new(), &vec![status]);
+        let posts = determine_posts(&Vec::new(), &vec![status], &DEFAULT_SYNC_OPTIONS);
         assert_eq!(posts.toots[0].text, "You & me!");
     }
 
@@ -517,7 +541,7 @@ UNLISTED 🔓 ✅ Tagged people
         status.reblog = Some(Box::new(reblog));
         status.reblogged = Some(true);
 
-        let posts = determine_posts(&vec![status], &Vec::new());
+        let posts = determine_posts(&vec![status], &Vec::new(), &DEFAULT_SYNC_OPTIONS);
         assert_eq!(posts.tweets[0].text, "RT example: Some example toooot!");
     }
 
@@ -531,7 +555,7 @@ UNLISTED 🔓 ✅ Tagged people
         status.reblog = Some(Box::new(reblog));
         status.reblogged = Some(true);
 
-        let posts = determine_posts(&vec![status], &Vec::new());
+        let posts = determine_posts(&vec![status], &Vec::new(), &DEFAULT_SYNC_OPTIONS);
         assert_eq!(posts.tweets[0].text, "RT example: longer than 280 characters longer than 280 characters longer than 280 characters longer than 280 characters longer than 280 characters longer than 280 characters longer than 280 characters longer than… https://example.com/a/b/c/5");
     }
 
@@ -550,7 +574,7 @@ UNLISTED 🔓 ✅ Tagged people
 
         let tweets = vec![tweet];
         let statuses = vec![status];
-        let posts = determine_posts(&statuses, &tweets);
+        let posts = determine_posts(&statuses, &tweets, &DEFAULT_SYNC_OPTIONS);
         assert!(posts.toots.is_empty());
         assert!(posts.tweets.is_empty());
     }
@@ -581,7 +605,7 @@ UNLISTED 🔓 ✅ Tagged people
         status.content = "@Test Hello! http://example.com".to_string();
         let tweets = Vec::new();
         let statuses = vec![status];
-        let posts = determine_posts(&statuses, &tweets);
+        let posts = determine_posts(&statuses, &tweets, &DEFAULT_SYNC_OPTIONS);
         assert!(posts.toots.is_empty());
         assert!(posts.tweets.is_empty());
     }
@@ -593,7 +617,7 @@ UNLISTED 🔓 ✅ Tagged people
         status.content = "Österreich".to_string();
         let tweets = Vec::new();
         let statuses = vec![status];
-        let posts = determine_posts(&statuses, &tweets);
+        let posts = determine_posts(&statuses, &tweets, &DEFAULT_SYNC_OPTIONS);
         assert!(posts.toots.is_empty());
         assert_eq!(posts.tweets[0].text, "Österreich");
     }
@@ -631,7 +655,7 @@ UNLISTED 🔓 ✅ Tagged people
     fn pictures_in_tweet() {
         let tweets = vec![get_twitter_status_media()];
         let statuses = Vec::new();
-        let posts = determine_posts(&statuses, &tweets);
+        let posts = determine_posts(&statuses, &tweets, &DEFAULT_SYNC_OPTIONS);
 
         let status = &posts.toots[0];
         assert_eq!(status.text, "Verhalten bei #Hausdurchsuchung");
@@ -651,7 +675,7 @@ UNLISTED 🔓 ✅ Tagged people
         let tweet = get_twitter_status_video();
         let tweets = vec![tweet];
         let statuses = Vec::new();
-        let posts = determine_posts(&statuses, &tweets);
+        let posts = determine_posts(&statuses, &tweets, &DEFAULT_SYNC_OPTIONS);
 
         let status = &posts.toots[0];
         assert_eq!(status.text, "Verhalten bei #Hausdurchsuchung");
@@ -671,7 +695,7 @@ UNLISTED 🔓 ✅ Tagged people
     fn pictures_in_toot() {
         let statuses = vec![get_mastodon_status_media()];
         let tweets = Vec::new();
-        let posts = determine_posts(&statuses, &tweets);
+        let posts = determine_posts(&statuses, &tweets, &DEFAULT_SYNC_OPTIONS);
 
         let tweet = &posts.tweets[0];
         assert_eq!(tweet.text, "test image");
@@ -696,7 +720,7 @@ UNLISTED 🔓 ✅ Tagged people
 
         let tweets = vec![retweet];
         let toots = Vec::new();
-        let posts = determine_posts(&toots, &tweets);
+        let posts = determine_posts(&toots, &tweets, &DEFAULT_SYNC_OPTIONS);
 
         let sync_toot = &posts.toots[0];
         assert_eq!(
@@ -718,7 +742,7 @@ UNLISTED 🔓 ✅ Tagged people
 
         let tweets = Vec::new();
         let toots = vec![boost];
-        let posts = determine_posts(&toots, &tweets);
+        let posts = determine_posts(&toots, &tweets, &DEFAULT_SYNC_OPTIONS);
 
         let sync_tweet = &posts.tweets[0];
         assert_eq!(sync_tweet.text, "RT example: test image");
@@ -753,7 +777,7 @@ UNLISTED 🔓 ✅ Tagged people
 
         let tweets = vec![quote_tweet];
         let toots = Vec::new();
-        let posts = determine_posts(&toots, &tweets);
+        let posts = determine_posts(&toots, &tweets, &DEFAULT_SYNC_OPTIONS);
 
         let sync_toot = &posts.toots[0];
         assert_eq!(
@@ -793,7 +817,7 @@ QT test123: Original text"
 
         let tweets = vec![quote_tweet];
         let toots = Vec::new();
-        let posts = determine_posts(&toots, &tweets);
+        let posts = determine_posts(&toots, &tweets, &DEFAULT_SYNC_OPTIONS);
 
         let sync_toot = &posts.toots[0];
         assert_eq!(
@@ -835,7 +859,7 @@ QT test123: Original text"
 
         let tweets = vec![quote_tweet];
         let toots = Vec::new();
-        let posts = determine_posts(&toots, &tweets);
+        let posts = determine_posts(&toots, &tweets, &DEFAULT_SYNC_OPTIONS);
 
         let sync_toot = &posts.toots[0];
         assert_eq!(
@@ -848,6 +872,79 @@ QT test123: Verhalten bei #Hausdurchsuchung"
             sync_toot.attachments[0].attachment_url,
             "https://pbs.twimg.com/media/Du70iGVUcAMgBp6.jpg"
         );
+    }
+
+    // Test that retweets are ignored when `sync_retweets` is `false`
+    #[test]
+    fn ignore_retweets() {
+        let mut original_tweet = get_twitter_status();
+        original_tweet.user = Some(Box::new(get_twitter_user()));
+        original_tweet.id = 1230906460160380928;
+
+        let mut retweet = get_twitter_status();
+        retweet.user = Some(Box::new(get_twitter_user()));
+        retweet.retweeted = Some(true);
+        retweet.retweeted_status = Some(Box::new(original_tweet));
+
+        let tweets = vec![retweet];
+        let toots = Vec::new();
+        let options = SyncOptions {
+            sync_reblogs: true,
+            sync_retweets: false,
+        };
+
+        let posts = determine_posts(&toots, &tweets, &options);
+        assert!(posts.toots.is_empty());
+        assert!(posts.tweets.is_empty());
+    }
+
+    // Test that quote tweets are synced without the quoted tweet when `sync_retweets=false`
+    #[test]
+    fn quote_tweets_are_synced_without_quoted_text() {
+        let mut original_tweet = get_twitter_status();
+        original_tweet.text = "Original text".to_string();
+        original_tweet.user = Some(Box::new(get_twitter_user()));
+        original_tweet.id = 1230906460160380928;
+
+        let mut quote_tweet = get_twitter_status();
+        quote_tweet.text = "Quote tweet test".to_string();
+        quote_tweet.quoted_status = Some(Box::new(original_tweet));
+
+        let tweets = vec![quote_tweet];
+        let toots = Vec::new();
+        let options = SyncOptions {
+            sync_reblogs: true,
+            sync_retweets: false,
+        };
+        let posts = determine_posts(&toots, &tweets, &options);
+
+        let sync_toot = &posts.toots[0];
+
+        assert_eq!(
+            sync_toot.text,
+            "Quote tweet test
+
+QT test123: Original text"
+        );
+    }
+
+    // Test that reblogs are ignored when `sync_reblogs` is `false`
+    #[test]
+    fn ignore_reblogs() {
+        let original_toot = get_mastodon_status();
+        let mut boost = get_mastodon_status();
+        boost.reblog = Some(Box::new(original_toot));
+
+        let tweets = Vec::new();
+        let toots = vec![boost];
+        let options = SyncOptions {
+            sync_reblogs: false,
+            sync_retweets: true,
+        };
+
+        let posts = determine_posts(&toots, &tweets, &options);
+        assert!(posts.toots.is_empty());
+        assert!(posts.tweets.is_empty());
     }
 
     fn get_mastodon_status() -> Status {


### PR DESCRIPTION
Introduce two new config options:
- `sync_retweets = false` ~~`ignore_retweets`~~ to exclude retweets when sychronizing from Twitter to Mastodon
- `sync_reblogs = false` ~~`ignore_boosts`~~ to exclude boosts (reblogs) when synchronizing from Mastodon to Twitter

Resolve #11 

~~Caveat: `mammut` does not support `exclude_reblogs` option introduced to Mastodon API in Dec 2018 via tootsuite/mastodon#9640, we have to filter out reblogs locally at client side. Mammut is no longer maintained and recomment users to migrate `elefren`. I opened a feature request asking `elefren` to add support for `exclude_reblogs`, see https://github.com/pwoolcoc/elefren/issues/134.~~

~~Discussion point: considering that Mastodon uses the term "reblogs" instead of "boosts", should we perhaps do the same and call the new parameter `ignore_reblogs`?~~