### PR TITLE
Cargo: enable link-time optimization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,6 @@ tempfile = ">=3"
 toml = ">=0.4.5"
 serde_json = ">=1.0.6"
 structopt = ">=0.2"
+
+[profile.release]
+lto = true


### PR DESCRIPTION
I am running mastodon-twitter-sync on my OpenWRT router and would like to keep the binary size as small as reasonably possible. The page https://github.com/johnthagen/min-sized-rust describes many tweaks for reducing the size. Some of them are easy, other are much more involved.

In this pull request, I am proposing to enable link-time optization for release builds. I _think_ it should not have any observable effects at runtime, while it reduces the binary size by approx. 25%.

| | |
-|-:
current size|1733 kB
link-time optimized|1373 kB
and stripped|958 kB
