### PR TITLE
refactor: simplify building of options in tests

### DIFF
--- a/src/sync.rs
+++ b/src/sync.rs
@@ -888,10 +888,8 @@ QT test123: Verhalten bei #Hausdurchsuchung"
 
         let tweets = vec![retweet];
         let toots = Vec::new();
-        let options = SyncOptions {
-            sync_reblogs: true,
-            sync_retweets: false,
-        };
+        let mut options = DEFAULT_SYNC_OPTIONS.clone();
+        options.sync_retweets = false;
 
         let posts = determine_posts(&toots, &tweets, &options);
         assert!(posts.toots.is_empty());
@@ -912,10 +910,9 @@ QT test123: Verhalten bei #Hausdurchsuchung"
 
         let tweets = vec![quote_tweet];
         let toots = Vec::new();
-        let options = SyncOptions {
-            sync_reblogs: true,
-            sync_retweets: false,
-        };
+        let mut options = DEFAULT_SYNC_OPTIONS.clone();
+        options.sync_retweets = false;
+
         let posts = determine_posts(&toots, &tweets, &options);
 
         let sync_toot = &posts.toots[0];
@@ -937,10 +934,8 @@ QT test123: Original text"
 
         let tweets = Vec::new();
         let toots = vec![boost];
-        let options = SyncOptions {
-            sync_reblogs: false,
-            sync_retweets: true,
-        };
+        let mut options = DEFAULT_SYNC_OPTIONS.clone();
+        options.sync_reblogs = false;
 
         let posts = determine_posts(&toots, &tweets, &options);
         assert!(posts.toots.is_empty());


### PR DESCRIPTION
Extracted from #18, where I noticed that adding a new sync option involves changes in many existing tests, which is not ideal.

- Replace the global constant `DEFAULT_SYNC_OPTIONS` with a factory function to obtain a new instance of the options object
- Rework tests using custom options to start with the default options and modify only the fields relevant in the test.

With this improvement in place, when we add a new sync option in the future, existing tests should not need any changes.