### PR TITLE
Allow sync only on string/hashtag

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ delete_older_statuses = true
 delete_older_favs = true
 # Also sync reblogs (boosts).
 sync_reblogs = true
+# Restrict sync to a hashtag (remove/leave empty if not desired)
+sync_hashtag = "#sync"
 
 [mastodon.app]
 base = "https://mastodon.social"
@@ -60,6 +62,8 @@ delete_older_statuses = true
 delete_older_favs = true
 # Also sync retweets.
 sync_retweets = true
+# Restrict sync to a hashtag (remove/leave empty if not desired)
+sync_hashtag = "#sync"
 ```
 
 ## Preview what's going to be synced

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ delete_older_statuses = true
 delete_older_favs = true
 # Also sync reblogs (boosts).
 sync_reblogs = true
-# Restrict sync to a hashtag (remove/leave empty if not desired)
+# Restrict sync to a hashtag (leave empty if not desired)
 sync_hashtag = "#sync"
 
 [mastodon.app]
@@ -62,7 +62,7 @@ delete_older_statuses = true
 delete_older_favs = true
 # Also sync retweets.
 sync_retweets = true
-# Restrict sync to a hashtag (remove/leave empty if not desired)
+# Restrict sync to a hashtag (leave empty if not desired)
 sync_hashtag = "#sync"
 ```
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ delete_older_statuses = true
 delete_older_favs = true
 # Also sync reblogs (boosts).
 sync_reblogs = true
-# Restrict sync to a hashtag (leave empty if not desired)
+# Restrict sync to a hashtag (leave empty to sync all posts)
 sync_hashtag = "#sync"
 
 [mastodon.app]
@@ -62,7 +62,7 @@ delete_older_statuses = true
 delete_older_favs = true
 # Also sync retweets.
 sync_retweets = true
-# Restrict sync to a hashtag (leave empty if not desired)
+# Restrict sync to a hashtag (leave empty to sync all posts)
 sync_hashtag = "#sync"
 ```
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -24,7 +24,7 @@ pub struct MastodonConfig {
     pub delete_older_favs: bool,
     #[serde(default = "config_true_default")]
     pub sync_reblogs: bool,
-    pub sync_hashtag: str,
+    pub sync_hashtag: String,
     pub app: Data,
 }
 
@@ -42,7 +42,7 @@ pub struct TwitterConfig {
     pub delete_older_favs: bool,
     #[serde(default = "config_true_default")]
     pub sync_retweets: bool,
-    pub sync_hashtag: str,
+    pub sync_hashtag: String,
 }
 
 fn config_false_default() -> bool {

--- a/src/config.rs
+++ b/src/config.rs
@@ -24,7 +24,7 @@ pub struct MastodonConfig {
     pub delete_older_favs: bool,
     #[serde(default = "config_true_default")]
     pub sync_reblogs: bool,
-    pub sync_hashtag: String,
+    pub sync_hashtag: Option<String>,
     pub app: Data,
 }
 
@@ -42,7 +42,7 @@ pub struct TwitterConfig {
     pub delete_older_favs: bool,
     #[serde(default = "config_true_default")]
     pub sync_retweets: bool,
-    pub sync_hashtag: String,
+    pub sync_hashtag: Option<String>,
 }
 
 fn config_false_default() -> bool {

--- a/src/config.rs
+++ b/src/config.rs
@@ -24,6 +24,7 @@ pub struct MastodonConfig {
     pub delete_older_favs: bool,
     #[serde(default = "config_true_default")]
     pub sync_reblogs: bool,
+    pub sync_hashtag: str,
     pub app: Data,
 }
 
@@ -41,6 +42,7 @@ pub struct TwitterConfig {
     pub delete_older_favs: bool,
     #[serde(default = "config_true_default")]
     pub sync_retweets: bool,
+    pub sync_hashtag: str,
 }
 
 fn config_false_default() -> bool {
@@ -108,6 +110,7 @@ mod tests {
 delete_older_statuses = true
 delete_older_favs = true
 sync_reblogs = false
+sync_hashtag = ""
 [mastodon.app]
 base = "https://mastodon.social"
 client_id = "abcd"
@@ -124,6 +127,7 @@ user_name = " "
 delete_older_statuses = true
 delete_older_favs = true
 sync_retweets = false
+sync_hashtag = ""
 "#;
         let config: Config = toml::from_str(toml_config).unwrap();
         toml::to_string(&config).unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,7 +48,7 @@ async fn run() -> Result<()> {
                     delete_older_statuses: false,
                     delete_older_favs: false,
                     sync_reblogs: true,
-                    sync_hashtag: "".to_string(),
+                    sync_hashtag: std::option::Option::Some("".to_string()),
                 },
                 twitter: twitter_config,
             };

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,6 +48,7 @@ async fn run() -> Result<()> {
                     delete_older_statuses: false,
                     delete_older_favs: false,
                     sync_reblogs: true,
+                    sync_hashtag: "".to_string(),
                 },
                 twitter: twitter_config,
             };

--- a/src/main.rs
+++ b/src/main.rs
@@ -118,6 +118,8 @@ async fn run() -> Result<()> {
     let options = SyncOptions {
         sync_reblogs: config.mastodon.sync_reblogs,
         sync_retweets: config.twitter.sync_retweets,
+        sync_hashtag_mastodon: config.mastodon.sync_hashtag,
+        sync_hashtag_twitter: config.twitter.sync_hashtag,
     };
 
     let mut posts = determine_posts(&mastodon_statuses, &tweets, &options);

--- a/src/registration.rs
+++ b/src/registration.rs
@@ -60,7 +60,7 @@ pub async fn twitter_register() -> Result<TwitterConfig> {
             delete_older_statuses: false,
             delete_older_favs: false,
             sync_retweets: true,
-            sync_hashtag: "".to_string(),
+            sync_hashtag: std::option::Option::Some("".to_string()),
         }),
         _ => unreachable!(),
     }

--- a/src/registration.rs
+++ b/src/registration.rs
@@ -60,6 +60,7 @@ pub async fn twitter_register() -> Result<TwitterConfig> {
             delete_older_statuses: false,
             delete_older_favs: false,
             sync_retweets: true,
+            sync_hashtag: "".to_string(),
         }),
         _ => unreachable!(),
     }

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -32,6 +32,8 @@ pub struct NewMedia {
 pub struct SyncOptions {
     pub sync_reblogs: bool,
     pub sync_retweets: bool,
+    pub sync_hashtag_twitter: String,
+    pub sync_hashtag_mastodon: String,
 }
 
 pub fn determine_posts(
@@ -414,6 +416,8 @@ mod tests {
     static DEFAULT_SYNC_OPTIONS: SyncOptions = SyncOptions {
         sync_reblogs: true,
         sync_retweets: true,
+        sync_hashtag_twitter: "".to_string(),
+        sync_hashtag_mastodon: "".to_string(),
     };
 
     #[test]

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -98,11 +98,20 @@ pub fn determine_posts(
                 break 'toots;
             }
         }
-        // The toot is not on Twitter yet, let's post it.
-        updates.tweets.push(NewStatus {
-            text: post,
-            attachments: toot_get_attachments(toot),
-        });
+
+        // The toot is not on Twitter yet, next step
+
+        // Check if hashtag filtering is enabled and if the toot matches
+        if !options.sync_hashtag_mastodon.is_empty() && !post.contains(&options.sync_hashtag_mastodon) {
+            // Skip if a sync hashtag is set and the string doesn't match
+            continue;
+        // Hashtag matches or sync hashtag not set, let's post it.
+        } else {
+            updates.tweets.push(NewStatus {
+                text: post,
+                attachments: toot_get_attachments(toot),
+            });
+        }
     }
     updates
 }

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -32,8 +32,8 @@ pub struct NewMedia {
 pub struct SyncOptions {
     pub sync_reblogs: bool,
     pub sync_retweets: bool,
-    pub sync_hashtag_twitter: String,
-    pub sync_hashtag_mastodon: String,
+    pub sync_hashtag_twitter: Option<String>,
+    pub sync_hashtag_mastodon: Option<String>,
 }
 
 pub fn determine_posts(
@@ -63,8 +63,10 @@ pub fn determine_posts(
 
         // Fetch the tweet text into a String object
         let decoded_tweet = tweet_unshorten_decode(tweet);
+        // Fetch the sync hashtag from the Option object for comfort
+        let sync_hashtag_twitter_value = options.sync_hashtag_twitter.as_deref().unwrap_or("");
         // Check if hashtag filtering is enabled and if the tweet matches
-        if !options.sync_hashtag_twitter.is_empty() && !decoded_tweet.contains(&options.sync_hashtag_twitter) {
+        if !sync_hashtag_twitter_value.is_empty() && !decoded_tweet.contains(&sync_hashtag_twitter_value) {
             // Skip if a sync hashtag is set and the string doesn't match
             continue;
         // Hashtag matches or sync hashtag not set, let's post it.
@@ -101,8 +103,10 @@ pub fn determine_posts(
 
         // The toot is not on Twitter yet, next step
 
+        // Fetch the sync hashtag from the Option object for comfort
+        let sync_hashtag_mastodon_value = options.sync_hashtag_mastodon.as_deref().unwrap_or("");
         // Check if hashtag filtering is enabled and if the toot matches
-        if !options.sync_hashtag_mastodon.is_empty() && !post.contains(&options.sync_hashtag_mastodon) {
+        if !sync_hashtag_mastodon_value.is_empty() && !post.contains(&sync_hashtag_mastodon_value) {
             // Skip if a sync hashtag is set and the string doesn't match
             continue;
         // Hashtag matches or sync hashtag not set, let's post it.
@@ -436,8 +440,8 @@ mod tests {
     static DEFAULT_SYNC_OPTIONS: SyncOptions = SyncOptions {
         sync_reblogs: true,
         sync_retweets: true,
-        sync_hashtag_twitter: "",
-        sync_hashtag_mastodon: "",
+        sync_hashtag_twitter: std::option::Option::None,
+        sync_hashtag_mastodon: std::option::Option::None,
     };
 
     #[test]

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -964,6 +964,62 @@ QT test123: Original text"
         assert!(posts.tweets.is_empty());
     }
 
+    // Test tagged posts are sent when hashtag is set
+    #[test]
+    fn tagged_posts_sent() {
+        let mut status = get_mastodon_status();
+        status.content = "Let's #tweet!".to_string();
+        let mut tweet = get_twitter_status();
+        tweet.text = "Let's #toot!".to_string();
+
+        let mut options = DEFAULT_SYNC_OPTIONS.clone();
+        options.sync_hashtag_twitter = std::option::Option::Some("#toot".to_string());
+        options.sync_hashtag_mastodon = std::option::Option::Some("#tweet".to_string());
+
+        let tweets = vec![tweet];
+        let toots = vec![status];
+
+        let posts = determine_posts(&toots, &tweets, &options);
+        assert!(!posts.toots.is_empty());
+        assert!(!posts.tweets.is_empty());
+    }
+
+    // Test posts without a tag are not sent
+    #[test]
+    fn ignore_untagged_posts() {
+        let mut status = get_mastodon_status();
+        status.content = "Let's NOT tweet!".to_string();
+        let mut tweet = get_twitter_status();
+        tweet.text = "Let's NOT toot!".to_string();
+
+        let mut options = DEFAULT_SYNC_OPTIONS.clone();
+        options.sync_hashtag_twitter = std::option::Option::Some("#toot".to_string());
+        options.sync_hashtag_mastodon = std::option::Option::Some("#tweet".to_string());
+
+        let tweets = vec![tweet];
+        let toots = vec![status];
+
+        let posts = determine_posts(&toots, &tweets, &options);
+        assert!(posts.toots.is_empty());
+        assert!(posts.tweets.is_empty());
+    }
+
+    // Test all posts are sent if hashtag config is unset
+    #[test]
+    fn no_hashtag_set_all_posts_sent() {
+        let mut status = get_mastodon_status();
+        status.content = "Let's #tweet!".to_string();
+        let mut tweet = get_twitter_status();
+        tweet.text = "Let's #toot!".to_string();
+
+        let tweets = vec![tweet];
+        let toots = vec![status];
+
+        let posts = determine_posts(&toots, &tweets, &DEFAULT_SYNC_OPTIONS);
+        assert!(!posts.toots.is_empty());
+        assert!(!posts.tweets.is_empty());
+    }
+
     fn get_mastodon_status() -> Status {
         read_mastodon_status("src/mastodon_status.json")
     }

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -58,11 +58,22 @@ pub fn determine_posts(
                 break 'tweets;
             }
         }
-        // The tweet is not on Mastodon yet, let's post it.
-        updates.toots.push(NewStatus {
-            text: tweet_unshorten_decode(tweet),
-            attachments: tweet_get_attachments(tweet),
-        });
+
+        // The tweet is not on Mastodon yet, next step
+
+        // Fetch the tweet text into a String object
+        let decoded_tweet = tweet_unshorten_decode(tweet);
+        // Check if hashtag filtering is enabled and if the tweet matches
+        if !options.sync_hashtag_twitter.is_empty() && !decoded_tweet.contains(&options.sync_hashtag_twitter) {
+            // Skip if a sync hashtag is set and the string doesn't match
+            continue;
+        // Hashtag matches or sync hashtag not set, let's post it.
+        } else {
+            updates.toots.push(NewStatus {
+                text: decoded_tweet,
+                attachments: tweet_get_attachments(tweet),
+            });
+        }
     }
 
     'toots: for toot in mastodon_statuses {

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -436,8 +436,8 @@ mod tests {
     static DEFAULT_SYNC_OPTIONS: SyncOptions = SyncOptions {
         sync_reblogs: true,
         sync_retweets: true,
-        sync_hashtag_twitter: "".to_string(),
-        sync_hashtag_mastodon: "".to_string(),
+        sync_hashtag_twitter: "",
+        sync_hashtag_mastodon: "",
     };
 
     #[test]


### PR DESCRIPTION
Fixes #7 - I've tested this with the `sync_hashtag` set to empty (everything syncs as usual) and I've tried it both ways with a hashtag. You can actually set different hashtags for Twitter and Mastodon if you want, and it will work with a string too - it doesn't *have* to be a hashtag either, I just left it like that in the docs because hashtags are what people are used to.