### PR TITLE
chore(build): refactor docker image building

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+/target
+/.github

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,7 +6,7 @@ on:
       - 'master'
 
 jobs:
-  docker:
+  docker-alpine:
     runs-on: ubuntu-latest
     environment: Docker
     steps:
@@ -23,8 +23,18 @@ jobs:
           username: klausi
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
-        name: Build and push
+        name: Build and push alpine image
         uses: docker/build-push-action@v2
         with:
           push: true
-          tags: klausi/mastodon-twitter-sync:latest
+          tags:
+            - klausi/mastodon-twitter-sync:latest
+            - klausi/mastodon-twitter-sync:alpine
+
+      -
+        name: Build and push debian image
+        uses: docker/build-push-action@v2
+        with:
+          file: ./debian.Dockerfile
+          push: true
+          tags: klausi/mastodon-twitter-sync:debian

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,30 @@
-# We get segmentation faults with the Alpine Rust image, so we use the bigger
-# default one.
-FROM rust:latest
+# This is for an image based on alpine.
 
-# Only if the Rust source files change do we need to recompile and invalidate
-# the Docker cache.
-WORKDIR /usr/src/mastodon-twitter-sync
-COPY src src
-COPY Cargo* ./
+FROM rust:1-alpine AS builder
 
-RUN cargo install --path .
+RUN apk add --no-cache musl-dev openssl-dev
+
+ENV USER=root
+WORKDIR /code
+RUN cargo init
+
+# Fetch all the dependencies without loading the code to have an independant layer
+COPY Cargo.lock Cargo.toml /code/
+RUN mkdir -p /code/.cargo
+RUN cargo vendor >> /code/.cargo/config.toml
+
+# Copy the source code and compile
+COPY src /code/src
+RUN cargo build --release --offline
+
+FROM alpine:latest
+
+RUN apk add --no-cache musl-dev
+
+COPY --from=builder /code/target/release/mastodon-twitter-sync /usr/bin/mastodon-twitter-sync
 
 # Use a separate workdir so that users can have a Docker volume with their
 # settings file. Cache files will also be written here.
 WORKDIR /data
 
-ENTRYPOINT ["mastodon-twitter-sync"]
+ENTRYPOINT ["/usr/bin/mastodon-twitter-sync"]

--- a/debian.Dockerfile
+++ b/debian.Dockerfile
@@ -1,0 +1,26 @@
+# This is for an image based on debian
+
+FROM rust:1-bullseye AS builder
+
+ENV USER=root
+WORKDIR /code
+RUN cargo init
+
+# Fetch all the dependencies without loading the code to have an independant layer
+COPY Cargo.lock Cargo.toml /code/
+RUN mkdir -p /code/.cargo
+RUN cargo vendor >> /code/.cargo/config.toml
+
+# Copy the source code and compile
+COPY src /code/src
+RUN cargo build --release --offline
+
+FROM debian:bullseye
+
+COPY --from=builder /code/target/release/mastodon-twitter-sync /usr/bin/mastodon-twitter-sync
+
+# Use a separate workdir so that users can have a Docker volume with their
+# settings file. Cache files will also be written here.
+WORKDIR /data
+
+ENTRYPOINT ["/usr/bin/mastodon-twitter-sync"]


### PR DESCRIPTION
This PR reduces the size of the docker image to 27Mo for the alpine image and 129Mo for the debian based image (could use slim tag to make it even smaller).

In a next PR, if you want, I could tackle the multi arch build (amd64, arm64 and armv7).