### PR TITLE
chore(ci): build multi arch alpine image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -28,3 +28,6 @@ jobs:
         with:
           push: true
           tags: klausi/mastodon-twitter-sync:latest
+          platforms:
+            - linux/amd64
+            - linux/arm64


### PR DESCRIPTION
Considering that the docker job installs qemu, I updated the dockerfile to be able to build a multiarch image for amd64 and arm64. I didn't check for armv7 though.
You'll notice another stage in the dockerfile to vendor the dependencies, it's done for 2 reasons, to only fetch them once for both architectures and to not fall in [this issue](https://github.com/rust-lang/cargo/issues/8719).

So we can now build a docker image working on both platform by doing

```bash
docker buildx build --platform linux/amd64,linux/arm64 --tag klausi/mastodon-twitter-sync .
```

Signed-off-by: Jérémie Drouet <jeremie.drouet@gmail.com>