### PR TITLE
Allow prefixing the syncing toots and tweets

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ delete_older_favs = true
 sync_reblogs = true
 # Restrict sync to a hashtag (leave empty to sync all posts)
 sync_hashtag = "#sync"
+# Add the prefix of toots to send  (leave empty to add nothing)
+sync_prefix = "[twitter] "
 
 [mastodon.app]
 base = "https://mastodon.social"
@@ -108,6 +110,8 @@ delete_older_favs = true
 sync_retweets = true
 # Restrict sync to a hashtag (leave empty to sync all posts)
 sync_hashtag = "#sync"
+# Add the prefix of tweets to send (leave empty to add nothing)
+sync_prefix = "[mastodon] "
 ```
 
 ## Preview what's going to be synced

--- a/src/config.rs
+++ b/src/config.rs
@@ -127,6 +127,40 @@ delete_older_statuses = true
 delete_older_favs = true
 sync_reblogs = false
 sync_hashtag = "#test"
+sync_prefix = "[T] "
+[mastodon.app]
+base = "https://mastodon.social"
+client_id = "abcd"
+client_secret = "abcd"
+redirect = "urn:ietf:wg:oauth:2.0:oob"
+token = "1234"
+[twitter]
+consumer_key = "abcd"
+consumer_secret = "abcd"
+access_token = "1234"
+access_token_secret = "1234"
+user_id = 0
+user_name = " "
+delete_older_statuses = true
+delete_older_favs = true
+sync_retweets = false
+sync_hashtag = "#test"
+sync_prefix = "[M] "
+"##;
+        let config: Config = toml::from_str(toml_config).unwrap();
+        toml::to_string(&config).unwrap();
+    }
+
+    // Ensure that serializing/deserializing of the TOML config does not throw
+    // errors.
+    #[test]
+    fn serialize_config_v1_8_0() {
+        let toml_config = r##"
+[mastodon]
+delete_older_statuses = true
+delete_older_favs = true
+sync_reblogs = false
+sync_hashtag = "#test"
 [mastodon.app]
 base = "https://mastodon.social"
 client_id = "abcd"

--- a/src/config.rs
+++ b/src/config.rs
@@ -31,6 +31,8 @@ pub struct MastodonConfig {
     #[serde(default = "config_none_default")]
     pub sync_hashtag: Option<String>,
     pub app: Data,
+    #[serde(default)] // empty string
+    pub sync_prefix: String,
 }
 
 #[serde_as]
@@ -51,6 +53,8 @@ pub struct TwitterConfig {
     #[serde_as(as = "NoneAsEmptyString")]
     #[serde(default = "config_none_default")]
     pub sync_hashtag: Option<String>,
+    #[serde(default)] // empty string
+    pub sync_prefix: String,
 }
 
 fn config_false_default() -> bool {

--- a/src/config.rs
+++ b/src/config.rs
@@ -30,9 +30,9 @@ pub struct MastodonConfig {
     #[serde_as(as = "NoneAsEmptyString")]
     #[serde(default = "config_none_default")]
     pub sync_hashtag: Option<String>,
-    pub app: Data,
     #[serde(default)] // empty string
     pub sync_prefix: String,
+    pub app: Data,
 }
 
 #[serde_as]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,7 +137,9 @@ pub fn run(args: Args) -> Result<()> {
 
     for toot in posts.toots {
         if !args.skip_existing_posts {
-            if let Err(e) = post_to_mastodon(&mastodon, &toot, args.dry_run) {
+            if let Err(e) =
+                post_to_mastodon(&mastodon, &toot, args.dry_run, &config.mastodon.sync_prefix)
+            {
                 println!("Error posting toot to Mastodon: {:#?}", e);
                 process::exit(5);
             }
@@ -152,7 +154,12 @@ pub fn run(args: Args) -> Result<()> {
 
     for tweet in posts.tweets {
         if !args.skip_existing_posts {
-            if let Err(e) = rt.block_on(post_to_twitter(&token, &tweet, args.dry_run)) {
+            if let Err(e) = rt.block_on(post_to_twitter(
+                &token,
+                &tweet,
+                args.dry_run,
+                &config.twitter.sync_prefix,
+            )) {
                 println!("Error posting tweet to Twitter: {:#?}", e);
                 process::exit(6);
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,7 @@ pub fn run(args: Args) -> Result<()> {
                     delete_older_favs: false,
                     sync_reblogs: true,
                     sync_hashtag: None,
+                    sync_prefix: Default::default(),
                 },
                 twitter: twitter_config,
             };

--- a/src/registration.rs
+++ b/src/registration.rs
@@ -56,6 +56,7 @@ pub async fn twitter_register() -> Result<TwitterConfig> {
             delete_older_favs: false,
             sync_retweets: true,
             sync_hashtag: None,
+            sync_prefix: Default::default(),
         }),
         _ => unreachable!(),
     }


### PR DESCRIPTION
Fix #79

## Description

Allow adding a prefix to the message, which is going to forward to Mastodon-side or Twitter-side. It is useful when you want to let readers know where this message is from.

<img width="425" alt="image" src="https://user-images.githubusercontent.com/28441561/202846519-552bfe5e-cc9b-435d-a85e-15a392a565de.png">

## Implementation

It will add prefix to *every* messages forward – it is implemented in `send_single_post_to_(side)`.
