### PR TITLE
fix(post): post in chronological order

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,7 +134,7 @@ pub fn run(args: Args) -> Result<()> {
     let mut cache_changed = false;
     posts = filter_posted_before(posts, &post_cache)?;
 
-    for toot in posts.toots {
+    for toot in posts.toots.into_iter().rev() {
         if !args.skip_existing_posts {
             if let Err(e) = post_to_mastodon(&mastodon, &toot, args.dry_run) {
                 println!("Error posting toot to Mastodon: {:#?}", e);
@@ -149,7 +149,7 @@ pub fn run(args: Args) -> Result<()> {
         }
     }
 
-    for tweet in posts.tweets {
+    for tweet in posts.tweets.into_iter().rev() {
         if !args.skip_existing_posts {
             if let Err(e) = rt.block_on(post_to_twitter(&token, &tweet, args.dry_run)) {
                 println!("Error posting tweet to Twitter: {:#?}", e);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,7 +134,7 @@ pub fn run(args: Args) -> Result<()> {
     let mut cache_changed = false;
     posts = filter_posted_before(posts, &post_cache)?;
 
-    for toot in posts.toots.into_iter().rev() {
+    for toot in posts.toots {
         if !args.skip_existing_posts {
             if let Err(e) = post_to_mastodon(&mastodon, &toot, args.dry_run) {
                 println!("Error posting toot to Mastodon: {:#?}", e);
@@ -149,7 +149,7 @@ pub fn run(args: Args) -> Result<()> {
         }
     }
 
-    for tweet in posts.tweets.into_iter().rev() {
+    for tweet in posts.tweets {
         if !args.skip_existing_posts {
             if let Err(e) = rt.block_on(post_to_twitter(&token, &tweet, args.dry_run)) {
                 println!("Error posting tweet to Twitter: {:#?}", e);


### PR DESCRIPTION
I ran `mastodon-twitter-sync` for the first time and it started posting my tweets to Mastodon in reverse order.

This PR fixes this issue and processes the tweets/toots in chronological order.
