### PR TITLE
Push the docker image to github container registry too

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -30,9 +30,18 @@ jobs:
           username: klausi
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
+        name: Login to github container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      -
         name: Build and push
         uses: docker/build-push-action@v3
         with:
           push: true
-          tags: klausi/mastodon-twitter-sync:latest
+          tags: |
+            klausi/mastodon-twitter-sync:latest
+            ghcr.io/${{ github.repository }}:latest
           platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
This displays the container image below the latest release on github:

![image](https://user-images.githubusercontent.com/7763184/210187397-1098f03e-1d1a-48d5-82c8-3d41cec26f8b.png)
