### PR TITLE
refactor(lint): fix clippy warnings

### DIFF
--- a/src/delete_favs.rs
+++ b/src/delete_favs.rs
@@ -21,7 +21,7 @@ pub fn mastodon_delete_older_favs(mastodon: &Mastodon, dry_run: bool) -> Result<
     let mut remove_dates = Vec::new();
     let three_months_ago = Utc::now() - Duration::days(90);
     for (date, toot_id) in dates.range(..three_months_ago) {
-        println!("Deleting Mastodon fav {} from {}", toot_id, date);
+        println!("Deleting Mastodon fav {toot_id} from {date}");
         // Do nothing on a dry run, just print what would be done.
         if dry_run {
             continue;
@@ -30,7 +30,7 @@ pub fn mastodon_delete_older_favs(mastodon: &Mastodon, dry_run: bool) -> Result<
         remove_dates.push(date);
         // The status could have been deleted already by the user, ignore API
         // errors in that case.
-        if let Err(error) = mastodon.unfavourite(&format!("{}", toot_id)) {
+        if let Err(error) = mastodon.unfavourite(&format!("{toot_id}")) {
             match error {
                 ElefrenError::Api(_) => {}
                 _ => return Err(error.into()),
@@ -90,7 +90,7 @@ pub async fn twitter_delete_older_favs(
     let mut remove_dates = Vec::new();
     let three_months_ago = Utc::now() - Duration::days(90);
     for (delete_count, (date, tweet_id)) in dates.range(..three_months_ago).enumerate() {
-        println!("Deleting Twitter fav {} from {}", tweet_id, date);
+        println!("Deleting Twitter fav {tweet_id} from {date}");
         // Do nothing on a dry run, just print what would be done.
         if dry_run {
             continue;

--- a/src/delete_statuses.rs
+++ b/src/delete_statuses.rs
@@ -26,7 +26,7 @@ pub fn mastodon_delete_older_statuses(
     let mut remove_dates = Vec::new();
     let three_months_ago = Utc::now() - Duration::days(90);
     for (date, toot_id) in dates.range(..three_months_ago) {
-        println!("Deleting toot {} from {}", toot_id, date);
+        println!("Deleting toot {toot_id} from {date}");
         // Do nothing on a dry run, just print what would be done.
         if dry_run {
             continue;
@@ -35,7 +35,7 @@ pub fn mastodon_delete_older_statuses(
         remove_dates.push(date);
         // The status could have been deleted already by the user, ignore API
         // errors in that case.
-        if let Err(error) = mastodon.delete_status(&format!("{}", toot_id)) {
+        if let Err(error) = mastodon.delete_status(&format!("{toot_id}")) {
             match error {
                 ElefrenError::Api(_) => {}
                 _ => return Err(error.into()),
@@ -97,7 +97,7 @@ pub async fn twitter_delete_older_statuses(
     let mut remove_dates = Vec::new();
     let three_months_ago = Utc::now() - Duration::days(90);
     for (date, tweet_id) in dates.range(..three_months_ago) {
-        println!("Deleting tweet {} from {}", tweet_id, date);
+        println!("Deleting tweet {tweet_id} from {date}");
         // Do nothing on a dry run, just print what would be done.
         if dry_run {
             continue;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,7 +69,7 @@ pub fn run(args: Args) -> Result<()> {
     let account = match mastodon.verify_credentials() {
         Ok(account) => account,
         Err(e) => {
-            eprintln!("Error connecting to Mastodon: {:#?}", e);
+            eprintln!("Error connecting to Mastodon: {e:#?}");
             process::exit(1);
         }
     };
@@ -77,7 +77,7 @@ pub fn run(args: Args) -> Result<()> {
     let mastodon_statuses = match mastodon.statuses(&account.id, StatusesRequest::new().limit(50)) {
         Ok(statuses) => statuses.initial_items,
         Err(e) => {
-            eprintln!("Error fetching toots from Mastodon: {:#?}", e);
+            eprintln!("Error fetching toots from Mastodon: {e:#?}");
             process::exit(2);
         }
     };
@@ -100,7 +100,7 @@ pub fn run(args: Args) -> Result<()> {
     let (timeline, first_tweets) = match rt.block_on(timeline.start()) {
         Ok(tweets) => tweets,
         Err(e) => {
-            eprintln!("Error fetching tweets from Twitter: {:#?}", e);
+            eprintln!("Error fetching tweets from Twitter: {e:#?}");
             process::exit(3);
         }
     };
@@ -111,7 +111,7 @@ pub fn run(args: Args) -> Result<()> {
         let (_, next_tweets) = match rt.block_on(timeline.older(None)) {
             Ok(tweets) => tweets,
             Err(e) => {
-                eprintln!("Error fetching older tweets from Twitter: {:#?}", e);
+                eprintln!("Error fetching older tweets from Twitter: {e:#?}");
                 process::exit(4);
             }
         };
@@ -137,7 +137,7 @@ pub fn run(args: Args) -> Result<()> {
     for toot in posts.toots {
         if !args.skip_existing_posts {
             if let Err(e) = post_to_mastodon(&mastodon, &toot, args.dry_run) {
-                eprintln!("Error posting toot to Mastodon: {:#?}", e);
+                eprintln!("Error posting toot to Mastodon: {e:#?}");
                 process::exit(5);
             }
         }
@@ -152,7 +152,7 @@ pub fn run(args: Args) -> Result<()> {
     for tweet in posts.tweets {
         if !args.skip_existing_posts {
             if let Err(e) = rt.block_on(post_to_twitter(&token, &tweet, args.dry_run)) {
-                eprintln!("Error posting tweet to Twitter: {:#?}", e);
+                eprintln!("Error posting tweet to Twitter: {e:#?}");
                 process::exit(6);
             }
         }
@@ -204,7 +204,7 @@ pub fn run(args: Args) -> Result<()> {
 /// Returns the full path for a cache file name.
 fn cache_file(name: &str) -> String {
     if let Ok(cache_dir) = std::env::var("MTS_CACHE_DIR") {
-        return format!("{}/{}", cache_dir, name);
+        return format!("{cache_dir}/{name}");
     }
     name.into()
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,9 +7,9 @@ fn main() {
     let args = Args::parse();
 
     if let Err(err) = run(args) {
-        eprintln!("Error: {}", err);
+        eprintln!("Error: {err}");
         for cause in err.chain().skip(1) {
-            eprintln!("Because: {}", cause);
+            eprintln!("Because: {cause}");
         }
         std::process::exit(1);
     }

--- a/src/registration.rs
+++ b/src/registration.rs
@@ -62,7 +62,7 @@ pub async fn twitter_register() -> Result<TwitterConfig> {
 }
 
 fn console_input(prompt: &str) -> Result<String> {
-    println!("{}: ", prompt);
+    println!("{prompt}: ");
     let mut line = String::new();
     let _ = io::stdin().read_line(&mut line)?;
     Ok(line.trim().to_string())

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -311,10 +311,9 @@ fn tweet_get_text_with_quote(tweet: &Tweet) -> String {
             }
 
             format!(
-                "{}
+                "{tweet_text}
 
-QT {}: {}",
-                tweet_text, screen_name, original_text
+QT {screen_name}: {original_text}"
             )
         }
     }

--- a/src/thread_replies.rs
+++ b/src/thread_replies.rs
@@ -117,7 +117,7 @@ pub fn determine_thread_replies(
                     text: post,
                     attachments: toot_get_attachments(toot),
                     in_reply_to_id: in_reply_to_id.parse::<u64>().unwrap_or_else(|_| {
-                        panic!("Mastodon reply ID is not u64: {}", in_reply_to_id)
+                        panic!("Mastodon reply ID is not u64: {in_reply_to_id}")
                     }),
                 },
             );


### PR DESCRIPTION
This PR simply fixes the warnings reported by clippy.

It is the result of:

```sh
$ cargo clippy --fix
```
