### PR TITLE
Count Twitter text length correctly by bumping egg-mode-text version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -363,9 +363,9 @@ dependencies = [
 
 [[package]]
 name = "egg-mode-text"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c83fe6fa4bcb27d9ebab2856f6515590ac621cac1f1dc51d9410b7e546d77ac"
+checksum = "32956c707081e778906fc194f400fb9e1c220a494f50eebd4a3bfe1224d21c27"
 dependencies = [
  "lazy_static",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ anyhow = ">=1"
 # See https://github.com/time-rs/time/issues/293
 chrono = { version = ">=0.4.23", default-features = false, features = ["std"] }
 clap = { version = ">=3.2.22", features = ["derive"] }
-egg-mode-text = ">=1.15.0"
+egg-mode-text = ">=1.15.1"
 env_logger = ">=0.7.1"
 html-escape = ">=0.2.11"
 log = ">=0.4.8"

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -606,7 +606,7 @@ UNLISTED 🔓 ✅ Tagged people
 ✅ Followers
 ✅ People who look for it
 ❌ Local and federated timelines
-✅ Boostable… https://mastodon.social/@klausi/98999025586548863"
+✅… https://mastodon.social/@klausi/98999025586548863"
         );
     }
 


### PR DESCRIPTION
fixing issue about tweet length calculation, see: https://github.com/egg-mode-rs/egg-mode-text/pull/3


a major change to the behavior is emoji should count as 2 in length, which is correct logic:

<img width="573" alt="image" src="https://user-images.githubusercontent.com/1443504/215940255-0d2afef6-ef6e-4660-b694-dd6627423b42.png">



