### PR TITLE
fix(sync): just skip failed post instead of crashing whole application

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -138,7 +138,7 @@ pub fn run(args: Args) -> Result<()> {
         if !args.skip_existing_posts {
             if let Err(e) = post_to_mastodon(&mastodon, &toot, args.dry_run) {
                 eprintln!("Error posting toot to Mastodon: {e:#?}");
-                process::exit(5);
+                continue;
             }
         }
         // Posting API call was successful: store text in cache to prevent any
@@ -153,7 +153,7 @@ pub fn run(args: Args) -> Result<()> {
         if !args.skip_existing_posts {
             if let Err(e) = rt.block_on(post_to_twitter(&token, &tweet, args.dry_run)) {
                 eprintln!("Error posting tweet to Twitter: {e:#?}");
-                process::exit(6);
+                continue;
             }
         }
         // Posting API call was successful: store text in cache to prevent any


### PR DESCRIPTION
(kind of) fixes #70 

I had something on twitter it somehow failed to download the attachment from the tweet, for whatever reason.
But as currently, if one post in either direction fails, it immediately crashes the program, all other posts that would have been fine weren't posted either.

This pull request changes the behaviour from using `process::exit(i32)` to just `continue` in these loops. This way the failed posts won't be added to the post_cache, but it doesn't block other working posts from being synced.

Don't if the bridge will even work after the 9th February, but hey, I at least get another week or so^^