### PR TITLE
docker shouldn't have '-it' as it's not interactive to work inside of…

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Every run of the program only synchronizes the accounts once. Use Cron to run it
 Or for the Docker version:
 
 ```
-*/10 * * * *   docker run -it --rm -v /home/klausi/workspace/mastodon-twitter-sync:/data klausi/mastodon-twitter-sync
+*/10 * * * *   docker run --rm -v /path/to/folder/mastodon-twitter-sync:/data klausi/mastodon-twitter-sync
 ```
 
 You can also use Github Actions for free to perform the periodic execution, the setup is explained in the [Periodic execution with Github Actions Cron](https://github.com/klausi/mastodon-twitter-sync/wiki/Periodic-execution-with-Github-Actions-Cron) wiki article.


### PR DESCRIPTION
There was a small issue in the documentation if wanting the docker to run as a cronjob. It should not be an interactive shell, I also tweaked the folder path example to be more obvious users can place the folder or file where needed. 