### PR TITLE
respect content warnings

### DIFF
--- a/src/post.rs
+++ b/src/post.rs
@@ -105,6 +105,10 @@ fn send_single_post_to_mastodon(mastodon: &Mastodon, toot: &NewStatus) -> Result
 
     let mut status_builder = StatusBuilder::new();
     status_builder.status(&toot.text);
+    if let Some(spoiler) = toot.content_warning.as_ref() {
+        status_builder.sensitive(true);
+        status_builder.spoiler_text(spoiler);
+    }
     status_builder.media_ids(media_ids);
     if let Some(parent_id) = toot.in_reply_to_id {
         status_builder.in_reply_to(parent_id.to_string());

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -1453,6 +1453,29 @@ QT test123: Original text"
         assert_eq!(tweet.attachments[0].alt_text, Some("a".repeat(1_000)));
     }
 
+    #[test]
+    fn tweet_add_content_warning() {
+        let fulltext = "blabalblabla";
+        let spoiler_text = "this is a unittest";
+        let expected = "CW: ".to_string() + spoiler_text + "\n\n" + fulltext;
+
+        assert_eq!(
+            expected,
+            add_content_warning_to_post_text(fulltext, spoiler_text)
+        );
+    }
+
+    #[test]
+    fn tweet_recognize_content_warning() {
+        let expected = "Some Unittest dude";
+        let decoded_tweet = "CW: ".to_string() + expected + "\nsome text";
+
+        assert_eq!(
+            expected,
+            tweet_find_content_warning(&decoded_tweet).unwrap()
+        );
+    }
+
     pub fn get_mastodon_status() -> Status {
         read_mastodon_status("src/mastodon_status.json")
     }


### PR DESCRIPTION
This adds a rudimentary implementation to transport content warnings out of Mastodon Spoilers in-line to a tweets text and vice and versa