### PR TITLE
use mastodon visibility

### DIFF
--- a/src/sync.rs
+++ b/src/sync.rs
@@ -3,6 +3,7 @@ use anyhow::Result;
 use egg_mode::tweet::Tweet;
 use egg_mode_text::character_count;
 use elefren::entities::status::Status;
+use elefren::status_builder::Visibility;
 use regex::Regex;
 use std::collections::HashSet;
 use std::fs;
@@ -134,9 +135,11 @@ pub fn determine_posts(
             None => tweet_shorten(&fulltext, &toot.url),
             Some(reblog) => tweet_shorten(&fulltext, &reblog.url),
         };
-        // Skip direct toots to other Mastodon users, even if they are public.
-        if post.starts_with('@') {
-            continue;
+
+        // ignore toots that are not public or unlisted
+        match toot.visibility {
+            Visibility::Public | Visibility::Unlisted => (),
+            _ => continue,
         }
 
         for tweet in twitter_statuses {

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -793,15 +793,51 @@ UNLISTED 🔓 ✅ Tagged people
         assert!(posts.tweets.is_empty());
     }
 
-    // Test that direct toots starting with "@" are not copied to twitter.
+    // Test that direct toots are not copied to twitter.
     #[test]
     fn direct_toot() {
         let mut status = get_mastodon_status();
-        status.content = "@Test Hello! http://example.com".to_string();
+        status.content = "Test Hello! http://example.com".to_string();
+        status.visibility = Visibility::Direct;
         let tweets = Vec::new();
         let statuses = vec![status];
         let posts = determine_posts(&statuses, &tweets, &DEFAULT_SYNC_OPTIONS);
-        assert!(posts.toots.is_empty());
+        assert!(posts.tweets.is_empty());
+    }
+
+    // test that public toots are synced
+    #[test]
+    fn public_toot() {
+        let mut status = get_mastodon_status();
+        status.content = "@Test Hello! http://example.com".to_string();
+        status.visibility = Visibility::Public;
+        let tweets = Vec::new();
+        let statuses = vec![status];
+        let posts = determine_posts(&statuses, &tweets, &DEFAULT_SYNC_OPTIONS);
+        assert_eq!(posts.tweets.len(), 1);
+    }
+
+    // test that unlisted toots are synced
+    #[test]
+    fn unlisted_toot() {
+        let mut status = get_mastodon_status();
+        status.content = "Test Hello! http://example.com".to_string();
+        status.visibility = Visibility::Unlisted;
+        let tweets = Vec::new();
+        let statuses = vec![status];
+        let posts = determine_posts(&statuses, &tweets, &DEFAULT_SYNC_OPTIONS);
+        assert_eq!(posts.tweets.len(), 1);
+    }
+
+    // test that private toots are NOT synced
+    #[test]
+    fn private_toot() {
+        let mut status = get_mastodon_status();
+        status.content = "Test Hello! http://example.com".to_string();
+        status.visibility = Visibility::Private;
+        let tweets = Vec::new();
+        let statuses = vec![status];
+        let posts = determine_posts(&statuses, &tweets, &DEFAULT_SYNC_OPTIONS);
         assert!(posts.tweets.is_empty());
     }
 

--- a/src/thread_replies.rs
+++ b/src/thread_replies.rs
@@ -1,6 +1,7 @@
 use crate::sync::*;
 use egg_mode::tweet::Tweet;
 use elefren::entities::status::Status;
+use elefren::status_builder::Visibility;
 
 // A reply to a post that has the ID to the parent post.
 #[derive(Debug)]
@@ -80,6 +81,12 @@ pub fn determine_thread_replies(
         if let Some(user_id) = &toot.in_reply_to_account_id {
             if user_id != &toot.account.id {
                 continue;
+            }
+
+            // ignore toots that are not public or unlisted
+            match toot.visibility {
+                Visibility::Public | Visibility::Unlisted => (),
+                _ => continue,
             }
 
             for tweet in twitter_statuses {


### PR DESCRIPTION
Atm all toots are synced, no matter what visibility on mastodon they have. The only consideration taken, is if a toot starts with an `@`, it is considered being directly addressing someone.  
Sometimes you start a toot by mentioning someone, but it is not meant as a private text and _should_ be synced, other times you write a toot _not_ starting with an `@`, but mark it explicitly as a direct toot to only mentioned people.

Especially the second case is problematic, as this exposes directly addressed toots as public on the twitter side.

This change makes use of the mastodon visibility set, and only syncs toots which are either public or unlisted, but not those set explicitly to be private to the Mastodon followers of the user or directly to just the mentioned users.